### PR TITLE
KG: add top level relations node and edge

### DIFF
--- a/se_lib/kg.rel
+++ b/se_lib/kg.rel
@@ -175,7 +175,7 @@ module se_kg
     @outline
     module despecialize_kg[KG]
         def NEW_KG(k, v) = despecialize(rn, k) and KG:node(rn, v) and RelName(rn) from rn
-        def NEW_KG(k, v1, v2) = despecialize(rn, k) and KG:edge(rn, v1, v2, xs...) and RelName(rn) and Entity(v1) and Entity(v2) from rn, xs...
+        def NEW_KG(k, v1, v2) = despecialize(rn, k) and KG:edge(rn, v1, v2) and RelName(rn) and Entity(v1) and Entity(v2) from rn
         //def NEW_KG(k1, k2, v) = despecialize(rn1, k1) and despecialize(rn2, k2) and KG(rn1, rn2, v) and RelName(rn1) and RelName(rn2) and Entity(v) from rn1, rn2
     end
 

--- a/se_lib/kg.rel
+++ b/se_lib/kg.rel
@@ -22,33 +22,29 @@ module se_kg
 
     // make knowledge graph (KG)
     // This function expects data model DATA and config META
-    // to create corresponding KG
-
-    //*** experiment with rewrite by Mary McGrath....
-    // @outline
-    // def make_knowledge_graph[DATA, META](entity_name in RelName, e in Entity) =
-    //         DATA(entity_rel, entity_attr, e, _) and
-    //         META(entity_rel, :entity_name, entity_name)
-    //         from entity_attr in RelName, entity_rel
-    // @outline
-    // def make_knowledge_graph[DATA, META](r in RelName, e1 in Entity, e2 in Entity) =
-    //         DATA(entity_rel, r, e1, e2, xs...)
-    //         from entity_rel in RelName, xs...
+    // to create corresponding KG that 
+    // contains node and edge sub-relations:
+    // node contains all entities such that:
+    //     (entity_type in RelName, entity in Hash)
+    // edge contains all relationships such that:
+    //     (relationship in RelName, entity1 in Hash, entity2 in Hash, xs...)
     @inline
-    def make_knowledge_graph[DATA, META] = {
-        {entity_name, e: _make_knowledge_graph_entities[DATA, META](entity_name, e)};
-        {r, e1, e2: _make_knowledge_graph_data[DATA](r, e1, e2)}
-    }
+    module make_knowledge_graph[DATA, META]
+        def node = {entity_type in RelName, e in Entity: _make_knowledge_graph_entities[DATA, META](entity_type, e)}
+        def edge = {r in RelName, e1, e2: _make_knowledge_graph_data[DATA](r, e1, e2)}
+    end
 
     @outline
-    def _make_knowledge_graph_entities[DATA, META](entity_name in RelName, e in Entity) =
+    def _make_knowledge_graph_entities[DATA, META](entity_type in RelName, e in Entity) =
+        exists(entity_rel in RelName, entity_attr in RelName:
             DATA(entity_rel, entity_attr, e, _) and
-            META(entity_rel, :entity_name, entity_name)
-            from entity_attr in RelName, entity_rel
+            META(entity_rel, :entity_name, entity_type)
+        )
     @outline
     def _make_knowledge_graph_data[DATA](r in RelName, e1 in Entity, e2 in Entity) =
+        exists(entity_rel in RelName, xs...: 
             DATA(entity_rel, r, e1, e2, xs...)
-            from entity_rel in RelName, xs...
+        )
 
     //*** end experiment
 
@@ -56,16 +52,16 @@ module se_kg
     @outline 
     module make_integer_kg[KG]
         def _map = transpose[enumerate[e in Entity:
-                                        (exists t in RelName: KG(t, e))
-                                        or (exists r in RelName, eo in Entity, xs...: KG(r, e, eo, xs...))
-                                        or (exists r in RelName, eo in Entity, xs...: KG(r, eo, e, xs...))]]
+                                        (exists t in RelName: KG(:node, t, e))
+                                        or (exists r in RelName, eo in Entity, xs...: KG(:edge, r, e, eo, xs...))
+                                        or (exists r in RelName, eo in Entity, xs...: KG(:edge, r, eo, e, xs...))]]
     end
     @outline
     def make_integer_kg[KG] {
         {t in RelName, n in Int: 
-            exists(e in Entity: KG(t, e) and make_integer_kg[KG][:_map](e, n))};
+            exists(e in Entity: KG(:node, t, e) and make_integer_kg[KG][:_map](e, n))};
         {r in RelName, n1 in Int, n2 in Int, xs...: 
-            exists(e1 in Entity, e2 in Entity: KG(r, e1, e2, xs...) and
+            exists(e1 in Entity, e2 in Entity: KG(:edge, r, e1, e2, xs...) and
             make_integer_kg[KG][:_map](e1, n1) and
             make_integer_kg[KG][:_map](e2, n2))}
     }
@@ -75,9 +71,10 @@ module se_kg
     @inline
     module make_graph[KG, is_directed_bool]
         def edge = n1 in Entity, n2 in Entity: 
-                    KG(r, n1, n2) 
-                    from r in RelName
-        def node = n: exists(t in RelName: KG(t, n))
+                    exists(r in RelName, xs...:
+                        KG:edge(r, n1, n2, xs...) 
+                    )
+        def node = n in Entity: exists(t in RelName: KG:node(t, n))
         def is_directed = if is_directed_bool=boolean_true then {()} else {} end 
     end
 
@@ -87,39 +84,38 @@ module se_kg
     // resulting mapping inside `map` relations.
     @inline
     module make_graph_with_map[KG, is_directed_bool]
-        def map(e, i) = enumerate[ee: KG(_, ee)](i, e)
-        def node = n: exists(t in RelName, e in Entity: KG(t, e) and map(e, n))
-        def edge = n1, n2: exists(r in RelName, e1 in Entity, e2 in Entity: 
-                        KG(r, e1, e2) and map(e1, n1) and map(e2, n2))
+        def map(e, i) = enumerate[ee: KG:node(_, ee)](i, e)
+        def node = n: exists(t in RelName, e in Entity: KG:node(t, e) and map(e, n))
+        def edge = n1, n2: exists(r in RelName, e1 in Entity, e2 in Entity, xs...: 
+                        KG:edge(r, e1, e2, xs...) and map(e1, n1) and map(e2, n2))
         def is_directed = if is_directed_bool=boolean_true then {()} else {} end 
     end 
 
-    @inline def  induce_kg_from_graph[G, KG] =
-        ename, e: KG(ename, e) and G:node(e)
-    @inline def induce_kg_from_graph[G, KG] =
-        ename, e1, e2: KG(ename, e1, e2) and G:edge(e1, e2)
+    @inline module induce_kg_from_graph[G, KG]
+        def node = ename, e: KG:node(ename, e) and G:node(e)
+        def edge = ename, e1, e2, xs...: KG:edge(ename, e1, e2, xs...) and G:edge(e1, e2)
+    end
 
-
-    @inline def subset_kg[KG, NODE](t, a) =
-        KG(t, a) and a=NODE
-    @inline def subset_kg[KG, NODE](r, a, b) =
-        KG(r, a, b) and a=NODE and b=NODE
+    @inline module subset_kg[KG, NODE]
+        def node(t, a) = KG:node(t, a) and a=NODE
+        def edge(r, a, b, xs...) = 
+            KG:edge(r, a, b, xs...) and a=NODE and b=NODE
+    end
 
     // filter KG by types of entities and types of relations
     // KG - knowledge graph to filter
     // TYPES - types of entities to filter by
     // RELATIONS - types of relations to filter by
-    @inline def filter_kg_by_type[KG, TYPES](t, a) =
-            KG(t, a) and t=TYPES
-    @inline def filter_kg_by_type[KG, TYPES](r, a, b) =
-            KG(r, a, b) and KG(TYPES, a) and KG(TYPES, b)
+    @inline module filter_kg_by_type[KG, TYPES]
+        def node(t, a) = KG:node(t, a) and t=TYPES
+        def edge(r, a, b, xs...) = 
+            KG:edge(r, a, b, xs...) and KG:node(TYPES, a) and KG:node(TYPES, b)
+    end
 
-    @inline def filter_kg_by_relation[KG, RELATIONS](t, a) {
-        KG(t, a) and (KG(RELATIONS, a, _) or KG(RELATIONS, _, a))
-    }
-    @inline def filter_kg_by_relation[KG, RELATIONS](r, a, b) {
-        KG(RELATIONS, a, b) and r=RELATIONS
-    }
+    @inline module filter_kg_by_relation[KG, RELATIONS]
+        def node(t, a) = KG:node(t, a) and (exists(xs...: KG:edge(RELATIONS, a, _, xs...)) or exists(ys...: KG:edge(RELATIONS, _, a, ys...))) 
+        def edge(r, a, b, xs...) = KG:edge(RELATIONS, a, b, xs...) and r=RELATIONS
+    end
 
     @inline
     def filter_kg[KG, TYPES, RELATIONS] =
@@ -136,10 +132,10 @@ module se_kg
 
     @inline
     module get_kg_signature[KG]
-        def total_nodes = count[r in RelName, e in Entity: KG(r, e)]
-        def total_edges = count[r in RelName, e1 in Entity, e2 in Entity: KG(r, e1, e2, xs...) and r!=:show from xs...]
-        def __entity_counts[r in RelName] = count[e: KG(r, e)]
-        def __relation_counts[r in RelName] = count[e1, e2: KG(r, e1, e2, xs...) and r!=:show from xs...]
+        def total_nodes = count[r in RelName, e in Entity: KG:node(r, e)]
+        def total_edges = count[r in RelName, e1 in Entity, e2 in Entity: KG:edge(r, e1, e2, xs...) and r!=:show from xs...]
+        def __entity_counts[r in RelName] = count[e: KG:node(r, e)]
+        def __relation_counts[r in RelName] = count[e1, e2: KG:edge(r, e1, e2, xs...) and r!=:show from xs...]
         def ___shows = count[xs...: KG(:show, xs...)]
     end
 
@@ -178,12 +174,12 @@ module se_kg
 
     @outline
     module despecialize_kg[KG]
-        def NEW_KG(k, v) = despecialize(rn, k) and KG(rn, v) and RelName(rn) from rn
-        def NEW_KG(k, v1, v2) = despecialize(rn, k) and KG(rn, v1, v2) and RelName(rn) and Entity(v1) and Entity(v2) from rn
-        def NEW_KG(k1, k2, v) = despecialize(rn1, k1) and despecialize(rn2, k2) and KG(rn1, rn2, v) and RelName(rn1) and RelName(rn2) and Entity(v) from rn1, rn2
+        def NEW_KG(k, v) = despecialize(rn, k) and KG:node(rn, v) and RelName(rn) from rn
+        def NEW_KG(k, v1, v2) = despecialize(rn, k) and KG:edge(rn, v1, v2, xs...) and RelName(rn) and Entity(v1) and Entity(v2) from rn, xs...
+        //def NEW_KG(k1, k2, v) = despecialize(rn1, k1) and despecialize(rn2, k2) and KG(rn1, rn2, v) and RelName(rn1) and RelName(rn2) and Entity(v) from rn1, rn2
     end
 
-    @outline def get_keys[KG](k) = KG(k, _)
+    @outline def get_keys[KG](k) = KG:node(k, _)
 
     @outline
     module distill_kg_ontology_graph[MODEL, DESPEC_KG]
@@ -228,10 +224,10 @@ module se_kg
     // KG - a knowledge graph to operate on
     // seeds or center - seed entity nodes
     // distance or radius - maximum distance from center to include nodes
-    @inline def induce_kg[KG, NODES](symb, n) = KG(symb, n) and NODES(n)
-    @inline def induce_kg[KG, NODES](symb, n, m) = KG(symb, n, m) and NODES(n) and NODES(m)
-    @outline def node[KG](n) = KG(_, n)
-    @outline def edge[KG](n, m) = KG(_, n, m); KG(_, m, n)
+    @inline def induce_kg[KG, NODES](:node, symb, n) = KG:node(symb, n) and NODES(n)
+    @inline def induce_kg[KG, NODES](:edge, symb, n, m) = KG:edge(symb, n, m) and NODES(n) and NODES(m)
+    @outline def node[KG](n) = KG:node(_, n)
+    @outline def edge[KG](n, m) = KG:edge(_, n, m); KG:edge(_, m, n)
 
     @outline
     module ego_graph[KG]
@@ -264,18 +260,18 @@ module se_kg
 
 
     // Prepare Knowledge Graph for graphviz
-    @outline
+    @outline       //@no_diagnostics(:TYPE_MISMATCH)
     module make_graphviz_object[KG, OPTS]
-        def node(e in Entity) = KG(r, e) from r in RelName
-        def edge(n1 in Entity, n2 in Entity) = KG(r, n1, n2) from r in RelName
+        def node(e in Entity) = KG:node(r, e) from r in RelName
+        def edge(n1 in Entity, n2 in Entity) = KG:edge(r, n1, n2, xs...) from r in RelName, xs...
 
         def node_attribute[n, "label"] = OPTS:ui:show[n], node(n)
 
         // graphviz options
-        def node_attribute[n, "shape"] = gv_shape_map[OPTS][t] from t where KG(t, n)
-        def node_attribute[n, gv_attr] = gv_color_map[OPTS][t] from t where KG(t, n) and
+        def node_attribute[n, "shape"] = gv_shape_map[OPTS][t] from t where KG:node(t, n)
+        def node_attribute[n, gv_attr] = gv_color_map[OPTS][t] from t where KG:node(t, n) and
                                             gv_attr = {"color"; "fontcolor"}
-        def node_attribute[n, "style"] = gv_style_map[OPTS][t] from t where KG(t, n)
+        def node_attribute[n, "style"] = gv_style_map[OPTS][t] from t where KG:node(t, n)
 
         // highlight nodes
         def node_attribute[n, "color"] = "red", OPTS:ui:node:highlight(n)
@@ -285,7 +281,7 @@ module se_kg
 
         def edge_attribute = x in Entity, y in Entity, "label", rstr:
                                 rstr=string[r] and
-                                KG(r, x, y) and
+                                KG:edge(r, x, y, xs...) and
                                     (OPTS:graphviz:label_edges <++ boolean_false)(boolean_true)
                                 // in the future consider using multiple dispatch around OPTS:graphviz:label_edges depending
                                 // on the type of relation. For example:
@@ -294,7 +290,7 @@ module se_kg
                                 // https://github.com/RelationalAI/raicode/blob/master/src/rel/vegalite.rel#L625
                                 // but at the level of
                                 // def edge_attribute = ...
-                                from r in RelName
+                                from r in RelName, xs...
 
         def layout = OPTS:graphviz:layout <++ "dot"
         def attribute:graph["rankdir"] = if layout="dot" then (OPTS:graphviz:direction <++ "LR") else {} end


### PR DESCRIPTION
Refactoring KG (knowledge graph) structure to always contain top level relations `node` and `edge`. All entities will move under `node` and all relationships will move under `edge` - everything is supposed to work as before. 
In reference: https://relationalai.atlassian.net/browse/SEI-6